### PR TITLE
add Linux tips page to Resources

### DIFF
--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -11,6 +11,15 @@
   <h3>Past Talks</h3>
 </section>
 <section>
+  <h3>Linux</h3>
+  <ul>
+    <li>
+      <a href="https://akselmo.dev/posts/how-to-linux-2025/">How to Linux</a>:
+      a fairly short blog post going over Linux basics and tips for new users.
+    </li>
+  </ul>
+</section>
+<section>
   <h3>Open-Source Software</h3>
   <ul>
     <li>


### PR DESCRIPTION
I read this post today and thought it would be a good fit for the resources section of the site :)

https://akselmo.dev/posts/how-to-linux-2025/